### PR TITLE
Fix for UL

### DIFF
--- a/src/hast/lists.ts
+++ b/src/hast/lists.ts
@@ -42,7 +42,7 @@ export const listElement = (
     class: `nesting-level-${nestingLevel}`,
   };
 
-  if (["GLYPH_TYPE_UNSPECIFIED", "NONE"].includes(glyphType)) {
+  if ([undefined, "GLYPH_TYPE_UNSPECIFIED", "NONE"].includes(glyphType)) {
     return h("ul", attributes);
   }
 


### PR DESCRIPTION
It seems like GoogleDocs API does not set `glyphType` for unordered lists